### PR TITLE
CircleCI の設定を変更

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -61,7 +61,7 @@ workflows:
           requires:
             - lint
             - test
-            - e2e
+            # - e2e
           filters:
             branches:
               only: release


### PR DESCRIPTION
#36 の対応漏れ

- e2e タスクをコメントアウトしていたのに deploy task が e2e の後に動くよう設定していたのでコメントアウト