### PR TITLE
Angular Material select の deprecated method の置き換え

### DIFF
--- a/src/app/components/season/season.component.html
+++ b/src/app/components/season/season.component.html
@@ -1,5 +1,5 @@
 <div class="mod-season">
-  <mat-select (change)="selectSeason($event)">
+  <mat-select (selectionChange)="selectSeason($event)">
     <mat-option *ngFor="let season of seasonList" [value]="season.value">
       {{season.displayName}}
     </mat-option>


### PR DESCRIPTION
## 対象 Issue
- #96 
